### PR TITLE
[FEATURE] Add Signet network for Bitcoin

### DIFF
--- a/lib/src/bitcoin/address/network_address.dart
+++ b/lib/src/bitcoin/address/network_address.dart
@@ -19,6 +19,7 @@ abstract class BitcoinNetworkAddress<T extends BasedUtxoNetwork> {
       case BitcoinNetwork.mainnet:
       case BitcoinNetwork.testnet:
       case BitcoinNetwork.testnet4:
+      case BitcoinNetwork.signet:
         baseAddress = BitcoinAddress.fromBaseAddress(address,
             network: network as BitcoinNetwork);
       case LitecoinNetwork.mainnet:
@@ -66,6 +67,7 @@ abstract class BitcoinNetworkAddress<T extends BasedUtxoNetwork> {
       case BitcoinNetwork.mainnet:
       case BitcoinNetwork.testnet:
       case BitcoinNetwork.testnet4:
+      case BitcoinNetwork.signet:
         baseAddress =
             BitcoinAddress(address, network: network as BitcoinNetwork);
       case LitecoinNetwork.mainnet:

--- a/lib/src/models/network.dart
+++ b/lib/src/models/network.dart
@@ -49,6 +49,7 @@ abstract class BasedUtxoNetwork implements Enumerate {
     BitcoinNetwork.mainnet,
     BitcoinNetwork.testnet,
     BitcoinNetwork.testnet4,
+    BitcoinNetwork.signet,
     LitecoinNetwork.mainnet,
     LitecoinNetwork.testnet,
     DashNetwork.mainnet,
@@ -144,6 +145,10 @@ class BitcoinNetwork implements BasedUtxoNetwork {
   /// Testnet4 configuration with associated `CoinConf`.
   static const BitcoinNetwork testnet4 = BitcoinNetwork._(
       'bitcoinTestnet4', CoinsConf.bitcoinTestNet, 'bitcoin:testnet4');
+
+  /// Signet configuration with associated `CoinConf`.
+  static const BitcoinNetwork signet = BitcoinNetwork._(
+      'bitcoinSignet', CoinsConf.bitcoinTestNet, 'bitcoin:signet');
 
   /// Overrides the `conf` property from `BasedUtxoNetwork` with the associated `CoinConf`.
   @override

--- a/lib/src/provider/constant/constant.dart
+++ b/lib/src/provider/constant/constant.dart
@@ -4,6 +4,7 @@ class BtcApiConst {
   static const String mempoolBaseURL = 'https://mempool.space/testnet/api';
   static const String mempoolTestnet4BaseURL =
       'https://mempool.space/testnet4/api';
+  static const String mempoolSignetBaseURL = 'https://mempool.space/signet/api';
   static const String blockstreamBaseURL =
       'https://blockstream.info/testnet/api';
   static const String blockCypherMainBaseURL =

--- a/lib/src/provider/models/config.dart
+++ b/lib/src/provider/models/config.dart
@@ -106,6 +106,9 @@ class APIConfig {
       case BitcoinNetwork.testnet4:
         baseUrl ??= BtcApiConst.mempoolTestnet4BaseURL;
         break;
+      case BitcoinNetwork.signet:
+        baseUrl ??= BtcApiConst.mempoolSignetBaseURL;
+        break;
       default:
         throw DartBitcoinPluginException(
             'mempool does not support ${network.conf.coinName.name}');


### PR DESCRIPTION
@mrtnetwork, thank you so much for this SDK! It's a real pleasure to work with code fully written in Dart — and having such a rich set of examples and detailed comments makes it even more enjoyable.

### What’s been done:
A new static method has been added to the BitcoinNetwork class to provide configuration for the Signet network.

### Why:
Signet is currently the most stable and recommended solution for testing in the Bitcoin ecosystem. Although all necessary parameters were already present in the SDK, explicit support for Signet was missing.

Moreover, some commercial Bitcoin API providers no longer support Test3 or Test4, making Signet the only viable option for certain development workflows.

### Additional notes:
I’ve tested the Signet settings to the best of my understanding — they appear to work just like Test3/Test4. If there are any inaccuracies, I’d be grateful for corrections. I verified functionality using the BitcoinApiService.